### PR TITLE
http gateway does not stringify data

### DIFF
--- a/http/gateway.js
+++ b/http/gateway.js
@@ -66,6 +66,10 @@ var HttpGateway = Extendable.extend({
             });
 
             if (data) {
+                if (_.isObject(data)) {
+                    data = JSON.stringify(data);
+                }
+
                 req.write(data);
             }
 


### PR DESCRIPTION
The HTTP gateway currently runs `JSON.stringify` on data that is passed in. We should not assume that all HTTP requests will be JSON requests.
