### PR TITLE
Create HttpAuthGateway

### DIFF
--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var HttpGateway = require('./gateway');
+var store       = require('store');
+
+var HttpAuthGateway = HttpGateway.extend({
+
+    _getRequestOptions : function(method, path)
+    {
+        var options, token;
+
+        options = HttpGateway.prototype._getRequestOptions.call(this, method, path);
+
+        token = store.get('token');
+        if (token) {
+            options.headers.Authorization = 'Bearer' + ' ' + token.access_token;
+        }
+
+        return options;
+    }
+
+});
+
+module.exports = HttpAuthGateway;

--- a/store/auth.js
+++ b/store/auth.js
@@ -1,29 +1,8 @@
 'use strict';
 
-var _         = require('underscore');
-var HttpStore = require('./http');
+var BaseStore       = require('./base');
+var HttpAuthGateway = require('../http/auth-gateway');
 
-var AuthStore = HttpStore.extend({
-    setTokenStore : function(tokenStore)
-    {
-        this.tokenStore = tokenStore;
-    },
-
-    _getRequestOptions : function(method, path)
-    {
-         var options = HttpStore.prototype._getRequestOptions.apply(this, arguments);
-
-         if (! this.tokenStore) {
-            throw "Missing tokenStore";
-         }
-
-         options.headers = options.headers || {};
-         options.headers = _.extend(options.headers, {
-            Authorization : 'Bearer ' + this.tokenStore.getAccessToken()
-         });
-
-        return options;
-    }
-});
+var AuthStore = BaseStore.extend(HttpAuthGateway.prototype);
 
 module.exports = AuthStore;

--- a/store/base.js
+++ b/store/base.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var Extendable   = require('../lib/extendable');
+var EventEmitter = require('events').EventEmitter;
+
+var BaseStore = Extendable.extend(EventEmitter.prototype);
+
+module.exports = BaseStore;

--- a/store/http.js
+++ b/store/http.js
@@ -1,8 +1,8 @@
 'use strict';
 
+var BaseStore    = require('./base');
 var HttpGateway  = require('../http/gateway');
-var EventEmitter = require('events').EventEmitter;
 
-var HttpStore = HttpGateway.extend(EventEmitter.prototype);
+var HttpStore = BaseStore.extend(HttpGateway.prototype);
 
 module.exports = HttpStore;


### PR DESCRIPTION
## Create HttpAuthGateway

It will work like HttpGateway, but will include the auth token if available.  If the token is not available, it should try making the request anyway, since it is possible for endpoints to exist that work with or without authorization.  The client code should be responsible for handling failures, including 401s.
### Acceptance Criteria
1. None
### Tasks
- Create http/auth-gateway that extends http/gateway and adds the Authorization header to the request using a token stored in local storage.
- Create store/base that extends EventEmitter.prototype
- Update store/http to extend store/base and http/gateway.
- Create store/auth that extends store/base and http/auth-gateway.
### Additional Notes
- None
