### PR TITLE
Emit '401-response-received' event on the dispatcher on 401 response in http/auth-gateway

### DIFF
--- a/http/gateway.js
+++ b/http/gateway.js
@@ -5,6 +5,7 @@ var Q            = require('q');
 var http         = require('http');
 var HttpError    = require('./error');
 var Extendable   = require('../lib/extendable');
+var dispatcher   = require('../lib/dispatcher');
 
 var HttpGateway = Extendable.extend({
 
@@ -50,6 +51,9 @@ var HttpGateway = Extendable.extend({
                     }
 
                     if (response.statusCode >= 400) {
+                        if (response.statusCode === 401) {
+                            dispatcher.emit('401-response-received');
+                        }
                         reject(new HttpError(responseData, response));
                     } else {
                         resolve(responseData);


### PR DESCRIPTION
## Emit '401-response-received' event on the dispatcher on 401 response in http/auth-gateway

The app can then listen and log out when this happens.
### Acceptance Criteria
1. Event is emitted whenever a request in http/auth-gateway returns a 401 response.
### Tasks
- Update http/auth-gateway
### Additional Notes
- None
