### PR TITLE
Make underscore a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "type" : "git",
     "url"  : "https://github.com/synapsestudios/synapse-common.git"
   },
+  "dependencies" : {
+    "q"          : "~1.0.0",
+    "underscore" : "1.7.0"
+  },
   "devDependencies" : {
     "browserify"                   : "5.10.1",
     "chai"                         : "1.9.1",
@@ -44,9 +48,5 @@
     "vinyl-source-stream"          : "0.1.1",
     "watchify"                     : "1.0.2",
     "watchr"                       : "2.4.11"
-  },
-  "peerDependencies" : {
-    "q"          : "~1.0.0",
-    "underscore" : "~1.6.0"
   }
 }


### PR DESCRIPTION
Underscore is used directly by synapse-common, not as a plugin. It needs to be listed as a dependency.

### Acceptance Criteria
1. Make underscore (and Q) a dependency, not a devDependency
1. Update underscore to 1.7.0