### PR TITLE
Update test-data-provider to work with Mocha

### DIFF
--- a/lib/test-data-provider.js
+++ b/lib/test-data-provider.js
@@ -1,3 +1,4 @@
+/* global mocha, jasmine */
 'use strict';
 
 /**
@@ -23,11 +24,11 @@ module.exports = function(description, values, func)
 {
     var count = values.length;
 
-    for (var i = 0; i < count; i++) {
+    for (var i = 0; i < count; i += 1) {
         if (Object.prototype.toString.call(values[i]) !== '[object Array]') {
             values[i] = [values[i]];
         }
         func.apply(this, values[i]);
-        jasmine.currentEnv_.currentSpec.description += ' (with "' + description + '" using ' + values[i].join(', ') + ')';
+        (mocha || jasmine).currentEnv_.currentSpec.description += ' (with "' + description + '" using ' + values[i].join(', ') + ')';
     }
 };


### PR DESCRIPTION
## Update test-data-provider to work with Mocha
### Acceptance Criteria
1. test-data-provider works with Mocha as well as Jasmine/Jest.
### Tasks
- None
### Additional Notes
- None
