### PR TITLE
Allow gateway and auth-gateway to use https

### DIFF
--- a/http/gateway.js
+++ b/http/gateway.js
@@ -37,7 +37,7 @@ var HttpGateway = Extendable.extend({
         return Q.Promise(_.bind(function(resolve, reject) {
             var options  = this._getRequestOptions(method, path);
 
-            var req = (gateway.config.secure ? https : http).request(options, function(response) {
+            var req = (gateway.getConfig().secure ? https : http).request(options, function(response) {
                 var responseText = '';
 
                 response.on('data', function(chunk) {


### PR DESCRIPTION
## Allow gateway and auth-gateway to use https
### Acceptance Criteria
1. If gateway.config.secure is set to true, requests are made using https.
### Tasks
- If gateway.config.secure is set to true, use the `https` module instead of `http`.
### Additional Notes
- None
