### PR TITLE
Upgrade peer dependency react version or remove it altogether

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "peerDependencies": {
     "q": "~1.0.0",
-    "react": "~0.11.0",
     "underscore": "~1.6.0"
   }
 }


### PR DESCRIPTION
## Upgrade peer dependency react version or remove it altogether

The peer dependency requirement is making it so the front end template's router can't be updated.
### Acceptance Criteria
1. {{list ACs here}}
### Tasks
- {{list developer tasks here}}
### Additional Notes
- Necessary for https://github.com/synapsestudios/frontend-template/issues/65
