### PR TITLE
update auth-gateway to handle refresh tokens

### DIFF
--- a/action/auth.js
+++ b/action/auth.js
@@ -1,0 +1,84 @@
+'use strict';
+
+var constants   = require('../constants');
+var oauthClient = require('../client/oauth');
+var userClient  = require('../client/user');
+
+var loginCreatedUser = function(password, userData) {
+    var flux = this;
+
+    // User created, now log in
+    oauthClient.login(userData.email, password)
+        .then(function(tokenData) {
+            flux.dispatch(
+                constants.LOGIN_SUCCESSFUL,
+                {
+                    tokenData : tokenData,
+                    userData  : userData
+                }
+            );
+        })
+        .fail(function() {
+            flux.dispatch(constants.LOGIN_FAILED);
+        });
+};
+
+var fetchLoggedInUser = function(tokenData)
+{
+    var flux = this;
+
+    // Authenticated, but still need user data
+    userClient.setToken(tokenData);
+    userClient.getCurrentUser()
+        .then(function(userData) {
+            flux.dispatch(
+                constants.LOGIN_SUCCESSFUL,
+                {
+                    tokenData : tokenData,
+                    userData  : userData
+                }
+            );
+        })
+        .fail(function() {
+            flux.dispatch(constants.LOGIN_FAILED);
+        });
+};
+
+module.exports = {
+    login : function(username, password)
+    {
+        var flux = this;
+
+        flux.dispatch(constants.LOGGING_IN);
+
+        oauthClient.login(username, password)
+            .then(fetchLoggedInUser.bind(flux))
+            .fail(function() {
+                flux.dispatch(constants.LOGIN_FAILED);
+            });
+    },
+
+    logout : function()
+    {
+        // Assume the logout worked, since it doesn't make a difference to the user
+        oauthClient.logout();
+
+        this.dispatch(constants.LOGOUT);
+    },
+
+    registerUser : function(email, password) {
+        var flux = this;
+
+        this.dispatch(constants.REGISTERING);
+
+        userClient.createUser(
+            {
+                email    : email,
+                password : password
+            })
+            .then(loginCreatedUser.bind(flux, password))
+            .fail(function() {
+                flux.dispatch(constants.REGISTRATION_FAILED);
+            });
+    }
+};

--- a/client/oauth.js
+++ b/client/oauth.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var config      = require('../config');
+var HttpGateway = require('synapse-common/http/auth-gateway');
+var qs          = require('querystring');
+var store       = require('store');
+
+var OAuthClient = HttpGateway.extend({
+
+    config : config.api,
+
+    login : function(email, password)
+    {
+        return this.apiRequest(
+            'POST',
+            '/oauth/token',
+            qs.stringify({
+                username      : email,
+                password      : password,
+                grant_type    : 'password',
+                client_id     : this.config.client_id,
+                client_secret : this.config.client_secret
+            })
+        );
+    },
+
+    logout : function()
+    {
+        var token = store.get('token') || {};
+
+        return this.apiRequest(
+            'POST',
+            '/oauth/logout',
+            {
+                refresh_token : token.refresh_token
+            }
+        );
+    },
+
+    _getRequestOptions : function(method, path)
+    {
+        var options;
+
+        options = HttpGateway.prototype._getRequestOptions.call(this, method, path);
+
+        options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+
+        return options;
+    }
+});
+
+module.exports = new OAuthClient();

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+    LOGGING_IN                              : 'LOGGING_IN',
+    LOGIN_FAILED                            : 'LOGIN_FAILED',
+    LOGIN_SUCCESSFUL                        : 'LOGIN_SUCCESSFUL',
+    LOGOUT                                  : 'LOGOUT',
+    REGISTERING                             : 'REGISTERING',
+    REGISTRATION_FAILED                     : 'REGISTRATION_FAILED',
+    REGISTRATION_SUCCESSFUL                 : 'REGISTRATION_SUCCESSFUL',
+    TOKEN_REFRESHED                         : 'TOKEN_REFRESHED'
+};

--- a/http/gateway.js
+++ b/http/gateway.js
@@ -6,7 +6,6 @@ var http         = require('http');
 var https        = require('https');
 var HttpError    = require('./error');
 var Extendable   = require('../lib/extendable');
-var dispatcher   = require('../lib/dispatcher');
 
 var HttpGateway = Extendable.extend({
 
@@ -62,7 +61,7 @@ var HttpGateway = Extendable.extend({
 
                     if (response.statusCode >= 400) {
                         if (response.statusCode === 401) {
-                            dispatcher.emit('401-response-received');
+                            this.handle401(method, path, data, headers, resolve, reject);
                         }
                         reject(new HttpError(responseData, response));
                     } else {
@@ -85,6 +84,20 @@ var HttpGateway = Extendable.extend({
 
             req.end();
         }, this));
+    },
+
+    /**
+     * Called when an api request fails with a 401
+     *
+     * @param  function method
+     * @param  string   path
+     * @param  mixed    data
+     * @param  function resolve
+     * @param  function reject
+     */
+    handle401 : function(method, path, data, headers, resolve, reject)
+    {
+        // override point
     },
 
     _getRequestOptions : function(method, path)

--- a/store/token.js
+++ b/store/token.js
@@ -16,7 +16,8 @@ var TokenStore = Fluxxor.createStore({
             constants.LOGGING_IN, 'onLogin',
             constants.LOGIN_SUCCESSFUL, 'onLoginSuccessful',
             constants.LOGIN_FAILED, 'onLoginFailed',
-            constants.LOGOUT, 'onLogout'
+            constants.LOGOUT, 'onLogout',
+            constants.TOKEN_REFRESHED, 'onRefresh'
         );
     },
 
@@ -51,6 +52,11 @@ var TokenStore = Fluxxor.createStore({
         this.loggedIn = false;
 
         this.emit('change');
+    },
+
+    onRefresh : function(payload)
+    {
+        // stub! update token
     },
 
     getTokenData : function()

--- a/store/token.js
+++ b/store/token.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var constants = require('../constants');
+var Fluxxor   = require('fluxxor');
+var store     = require('store');
+
+var TokenStore = Fluxxor.createStore({
+
+    initialize : function()
+    {
+        this.loading  = false;
+        this.error    = false;
+        this.loggedIn = !! store.get('token');
+
+        this.bindActions(
+            constants.LOGGING_IN, 'onLogin',
+            constants.LOGIN_SUCCESSFUL, 'onLoginSuccessful',
+            constants.LOGIN_FAILED, 'onLoginFailed',
+            constants.LOGOUT, 'onLogout'
+        );
+    },
+
+    onLogin : function()
+    {
+        this.loading = true;
+
+        this.emit('change');
+    },
+
+    onLoginSuccessful : function(payload)
+    {
+        this.token    = payload.tokenData;
+        this.loggedIn = true;
+
+        store.set('token', this.token);
+
+        this.emit('change');
+    },
+
+    onLoginFailed : function()
+    {
+        this.loading = false;
+        this.error   = true;
+
+        this.emit('change');
+    },
+
+    onLogout : function()
+    {
+        store.remove('token');
+        this.loggedIn = false;
+
+        this.emit('change');
+    },
+
+    getTokenData : function()
+    {
+        return store.get('token');
+    }
+});
+
+module.exports = TokenStore;
+


### PR DESCRIPTION
## Update auth-gateway to handle refresh tokens

### Acceptance Criteria
1. The auth gateway will require that a flux object be inject into it in order to complete api requests.
1. The auth gateway will be updated to interact with the token through the token store rather than directly in local storage.
1. The token store will be moved into synapse common
1. The auth action will be moved into synapse common
1. The oauth client will be moved into synapse common
1. When an api call fails with a 401 the auth gateway will attempt to do a auth refresh using the oauth refresh token. If refresh succeeds then it will dispatch a token update event and retry the original api request using the resolve and reject methods that were passed by the caller.
1. If the refresh token fails dispatch a logout event
1. Remove event.js and dispatcher.js (flux stuff is taking over the functionality of these files)