### PR TITLE
Handle expired access tokens

### DIFF
--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -26,6 +26,16 @@ var HttpAuthGateway = HttpGateway.extend({
      *
      * Assume that the oauth access token has expired and the refresh token
      * needs to be exchanged for a new one.
+     *
+     * The successful response of the refresh token exchange request will be
+     * in the following shape:
+     * {
+     *     "access_token" : "6339f1a7...",
+     *     "expires_in"   : 3600,
+     *     "token_type"   : "bearer",
+     *     "scope"        : null,
+     *     "user_id"      : "1"
+     * }
      */
     handle401 : function(resolve, reject, method, path, data, headers)
     {
@@ -36,8 +46,8 @@ var HttpAuthGateway = HttpGateway.extend({
 
         data = data || {};
 
-        handleSuccess = function (accessToken) {
-            token = _.extend(token, accessToken);
+        handleSuccess = function (response) {
+            token = _.extend(token, response);
 
             store.set('token', token);
 

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -2,14 +2,16 @@
 
 var HttpGateway = require('./gateway');
 var store       = require('store');
+var qs          = require('querystring');
+var _           = require('underscore');
 
 var HttpAuthGateway = HttpGateway.extend({
 
-    _getRequestOptions : function(method, path)
+    getRequestOptions : function(method, path, data)
     {
         var options, token;
 
-        options = HttpGateway.prototype._getRequestOptions.call(this, method, path);
+        options = HttpGateway.prototype.getRequestOptions.call(this, method, path, data);
 
         token = store.get('token');
         if (token) {
@@ -17,6 +19,44 @@ var HttpAuthGateway = HttpGateway.extend({
         }
 
         return options;
+    },
+
+    /**
+     * Handle 401 Unauthorized responses
+     *
+     * Assume that the oauth access token has expired and the refresh token
+     * needs to be exchanged for a new one.
+     */
+    handle401 : function(resolve, reject, method, path, data, headers)
+    {
+        var gateway, token, refreshData, refreshHeaders, handleSuccess, handleFailure;
+
+        gateway = this;
+        token   = store.get('token');
+
+        data = data || {};
+
+        handleSuccess = function (accessToken) {
+            token = _.extend(token, accessToken);
+
+            store.set('token', token);
+
+            gateway.apiRequest(method, path, data, headers).then(resolve, reject);
+        };
+
+        handleFailure = function (errors) {
+            // Noop
+        };
+
+        refreshData = qs.stringify({
+            client_id     : this.config.client_id,
+            grant_type    : 'refresh_token',
+            refresh_token : token.refresh_token
+        });
+
+        refreshHeaders = {'Content-Type' : 'application/x-www-form-urlencoded'};
+
+        this.apiRequest('POST', '/oauth/token', refreshData, refreshHeaders).then(handleSuccess, handleFailure);
     }
 
 });

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -22,6 +22,20 @@ var HttpAuthGateway = HttpGateway.extend({
     },
 
     /**
+     * {@inheritDoc}
+     */
+    handleError : function(response, responseData, resolve, reject, method, path, data, headers)
+    {
+        if (response.statusCode === 401) {
+            this.handle401(resolve, reject, method, path, data, headers);
+
+            return;
+        }
+
+        HttpGateway.prototype.handleError(response, responseData, resolve, reject, method, path, data, headers);
+    },
+
+    /**
      * Handle 401 Unauthorized responses
      *
      * Assume that the oauth access token has expired and the refresh token

--- a/http/gateway.js
+++ b/http/gateway.js
@@ -56,13 +56,7 @@ var HttpGateway = Extendable.extend({
                     }
 
                     if (response.statusCode >= 400) {
-                        if (response.statusCode === 401) {
-                            shouldReject = gateway.handle401(resolve, reject, method, path, data, headers);
-                        }
-
-                        if (response.statusCode !== 401 || shouldReject === true) {
-                            reject(new HttpError(responseData, response));
-                        }
+                        gateway.handleError(response, responseData, resolve, reject, method, path, data, headers);
                     } else {
                         resolve(responseData);
                     }
@@ -168,13 +162,20 @@ var HttpGateway = Extendable.extend({
     },
 
     /**
-     * Handle 401 Unauthorized responses
+     * Handle API request errors
      *
-     * Return true to indicate that 401 will not be handled
+     * @param  {Object}   response     The API response
+     * @param  {Mixed}    responseData The data returned in the response
+     * @param  {Function} resolve      The success callback
+     * @param  {Function} reject       The fail callback
+     * @param  {String}   method       The failed request's method
+     * @param  {String}   path         The failed request's path
+     * @param  {Object}   data         The failed request body data (if any)
+     * @param  {Object}   headers      The extra headers set on the failed request
      */
-    handle401 : function(resolve, reject, method, path, data, headers)
+    handleError : function(response, responseData, resolve, reject, method, path, data, headers)
     {
-        return true;
+        reject(new HttpError(responseData, response));
     }
 
 });

--- a/http/gateway.js
+++ b/http/gateway.js
@@ -58,9 +58,9 @@ var HttpGateway = Extendable.extend({
                     if (response.statusCode >= 400) {
                         if (response.statusCode === 401) {
                             gateway.handle401(resolve, reject, method, path, data, headers);
+                        } else {
+                            reject(new HttpError(responseData, response));
                         }
-
-                        reject(new HttpError(responseData, response));
                     } else {
                         resolve(responseData);
                     }

--- a/http/gateway.js
+++ b/http/gateway.js
@@ -47,7 +47,7 @@ var HttpGateway = Extendable.extend({
                 });
 
                 response.on('end', function() {
-                    var responseData;
+                    var responseData, shouldReject;
 
                     try {
                         responseData = JSON.parse(responseText);
@@ -57,8 +57,10 @@ var HttpGateway = Extendable.extend({
 
                     if (response.statusCode >= 400) {
                         if (response.statusCode === 401) {
-                            gateway.handle401(resolve, reject, method, path, data, headers);
-                        } else {
+                            shouldReject = gateway.handle401(resolve, reject, method, path, data, headers);
+                        }
+
+                        if (response.statusCode !== 401 || shouldReject === true) {
                             reject(new HttpError(responseData, response));
                         }
                     } else {
@@ -167,10 +169,12 @@ var HttpGateway = Extendable.extend({
 
     /**
      * Handle 401 Unauthorized responses
+     *
+     * Return true to indicate that 401 will not be handled
      */
     handle401 : function(resolve, reject, method, path, data, headers)
     {
-        // Noop
+        return true;
     }
 
 });


### PR DESCRIPTION
## Handle expired access tokens

### Acceptance Criteria
1. Whenever an API call made through the auth-gateway returns 401, it assumes that the access token has expired.
1. It then tries to exchange the refresh token for a new access token.
1. When the new access token is returned, it is saved. Then, the original failed request is re-made and its success/failure callback correctly attached.
1. If the refresh token fails dispatch a logout event
1. Remove event.js and dispatcher.js (flux stuff is taking over the functionality of these files)

### Tasks
- Modify auth-gateway and gateway to perform refresh token exchange.

### Other Notes
- Plan B of #25