### PR TITLE
Make upgrade guide for 0.1.x to 0.3.x

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,0 +1,33 @@
+Upgrade Guide
+=============
+
+Pre-0.3.0 -> 0.3.x
+------------------
+
+### Update clients which override `_getRequestOptions`
+
+In 0.3.0, the base gateway's `_getRequestOptions` method was renamed to `getRequestOptions`. For `client`s that override that method, it should be renamed to follow suit.
+
+```js
+// < 0.3.0
+var UserClient = HttpGateway.extend({
+    //...
+    _getRequestOptions : function(method, path)
+    {
+        var options = HttpGateway.prototype._getRequestOptions.call(this, method, path);
+
+        // ...
+    }
+});
+
+// 0.3.x
+var UserClient = HttpGateway.extend({
+    //...
+    getRequestOptions : function(method, path)
+    {
+        var options = HttpGateway.prototype.getRequestOptions.call(this, method, path);
+
+        // ...
+    }
+});
+```


### PR DESCRIPTION
Had some difficulties upgrading which ended up being in the `getRequestOptions` overrides in `oauth.js` and `user.js` clients. The new version removes underscores from the function name, but the older frontend template was overriding them with underscores, causing login to break with an obscure error. See: synapsestudios/frontend-template#68