### PR TITLE
Better handling of failed refresh token requests

### DIFF
--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -86,7 +86,15 @@ var HttpAuthGateway = HttpGateway.extend({
         };
 
         handleFailure = function (errors) {
-            // Noop
+            var config = gateway.getConfig();
+
+            store.clear();
+
+            if (config.login_url) {
+                window.location = config.login_url;
+            } else {
+                window.location = '/';
+            }
         };
 
         refreshData = qs.stringify({


### PR DESCRIPTION
## Description

Filing this as a bug because it is, IMO. Currently if the authorization token is expired, we try requesting a refresh token. However, if the request for a refresh token fails (eg, it expired since the user last tried to access the site), we call an empty function and don't alert the frontend at all. We should have a way to hook this so that we can call a "logout" action on the frontend.

See: https://github.com/synapsestudios/synapse-common/blob/master/http/auth-gateway.js#L88

## Details

- Credentials: {{username / password (remove if not applicable)}}
- URL: {{url where problem occurs, remove if not applicable}}
- Note: {{relevant information like related issues, remove if not applicable}}
- Console Error: {{expand and copy from the console (include line error too), remove if not applicable}}