### PR TITLE
Auth gateway fails to set token after 401 response

### DIFF
--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -80,7 +80,7 @@ var HttpAuthGateway = HttpGateway.extend({
         handleSuccess = function (response) {
             token = _.extend(token, response);
 
-            store.set(this.tokenStorageLocation, token);
+            store.set(gateway.tokenStorageLocation, token);
 
             gateway.apiRequest(method, path, data, headers).then(resolve, reject);
         };


### PR DESCRIPTION
The access token is never updated, so all attempts to refresh tokens will fail.