### PR TITLE
Loosen fluxxor peerDependency version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   },
   "dependencies": {
     "q": "~1.0.0",
-    "fluxxor": "~1.4.0",
     "store": "1.3.17",
     "underscore": "1.7.0"
+  },
+  "peerDependencies": {
+    "fluxxor": "^1.4"
   },
   "devDependencies": {
     "browserify": "5.10.1",


### PR DESCRIPTION
## Loosen fluxxor peerDependency version constraint, so that apps can upgrade fluxxor up to the next major version

### Acceptance Criteria
1. Fluxxor peerDependency is specified with `^` rather than `~`.

### Tasks
- Change `~` to `^`.
- Move fluxxor to peerDependencies

### Additional Notes
- We once had underscore as a peerDependency, and it unnecessarily kept applications from upgrading. It was a pain.