### PR TITLE
Extra configuration for API prefix and token/login endpoints

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -5,7 +5,7 @@ Pre-1.4.0 -> 1.4.0
 ------------------
 ### API config should include oauth endpoints and API url
 
-The `auth-gateway` was refactored to expect the oauth token endpoint to be set in the app configuration. Further, the api URL and api proxy prefix are requiredto be set in the config. Requests to `[hostname]:[port]/api/[uri]` will be proxied to `[url]/[uri]`
+The `auth-gateway` was refactored to expect the oauth token endpoint to be set in the app configuration. Further, the api URL and api proxy prefix are requiredto be set in the config. Requests to `[api.hostname]:[api.port]/[prefix]/[uri]` will be proxied to `[proxy.hostname]/[uri]`
 
 ```JavaScript
 module.exports = {

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,6 +1,28 @@
 Upgrade Guide
 =============
 
+Pre-1.4.0 -> 1.4.0
+------------------
+### API config should include oauth endpoints and API url
+
+The `auth-gateway` was refactored to expect the oauth token endpoint to be set in the app configuration
+
+```JavaScript
+module.exports = {
+    api : {
+        client_id : '123',
+        hostname  : 'localhost',
+        port      : 9000,
+        oauth     : {
+            logout : '/api/oauth/logout',
+            token  : '/api/oauth/token'
+        },
+        url : ''
+    },
+    login_url : '/login'
+};
+```
+
 Pre-1.2.0 -> 1.2.0
 ------------------
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -5,7 +5,7 @@ Pre-1.4.0 -> 1.4.0
 ------------------
 ### API config should include oauth endpoints and API url
 
-The `auth-gateway` was refactored to expect the oauth token endpoint to be set in the app configuration
+The `auth-gateway` was refactored to expect the oauth token endpoint to be set in the app configuration. Further, the api URL and api proxy prefix are requiredto be set in the config. Requests to `[hostname]:[port]/api/[uri]` will be proxied to `[url]/[uri]`
 
 ```JavaScript
 module.exports = {
@@ -16,11 +16,13 @@ module.exports = {
             logout : '/api/oauth/logout',
             token  : '/api/oauth/token'
         },
-        port      : 9000,
-        prefix    : '/api',
-        url       : ''
+        port   : 9000,
+        prefix : '/api'
     },
-    login_url : '/login'
+    login_url : '/login',
+    proxy     : {
+        hostname : 'api.project.vm'
+    }
 };
 ```
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -5,7 +5,7 @@ Pre-1.4.0 -> 1.4.0
 ------------------
 ### API config should include oauth endpoints and API url
 
-The `auth-gateway` was refactored to expect the oauth token endpoint to be set in the app configuration. Further, the api URL and api proxy prefix are requiredto be set in the config. Requests to `[api.hostname]:[api.port]/[prefix]/[uri]` will be proxied to `[proxy.hostname]/[uri]`
+The `auth-gateway` was refactored to expect the oauth token endpoint to be set in the app configuration. Further, the API URL and API proxy prefix are required to be set in the config. Requests to `[api.hostname]:[api.port]/[api.prefix]/{uri}` will be proxied to `[proxy.hostname]/{uri}`
 
 ```JavaScript
 module.exports = {

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -12,12 +12,13 @@ module.exports = {
     api : {
         client_id : '123',
         hostname  : 'localhost',
-        port      : 9000,
         oauth     : {
             logout : '/api/oauth/logout',
             token  : '/api/oauth/token'
         },
-        url : ''
+        port      : 9000,
+        prefix    : '/api',
+        url       : ''
     },
     login_url : '/login'
 };

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -13,8 +13,8 @@ module.exports = {
         client_id : '123',
         hostname  : 'localhost',
         oauth     : {
-            logout : '/api/oauth/logout',
-            token  : '/api/oauth/token'
+            logout : '/oauth/logout',
+            token  : '/oauth/token'
         },
         port   : 9000,
         prefix : '/api'

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -116,7 +116,7 @@ var HttpAuthGateway = HttpGateway.extend({
         }
 
         if (this.config.prefix) {
-            tokenUri = prefix + tokenUri;
+            tokenUri = this.config.prefix + tokenUri;
         }
 
         this.apiRequest('POST', tokenUri, refreshData, refreshHeaders).then(handleSuccess, handleFailure);

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -105,7 +105,15 @@ var HttpAuthGateway = HttpGateway.extend({
 
         refreshHeaders = {'Content-Type' : 'application/x-www-form-urlencoded'};
 
-        tokenUri = this.config.oauth.token;
+        if (this.config.oauth && this.config.oauth.token) {
+            tokenUri = this.config.oauth.token;
+        } else {
+            console.warn(
+                'Oauth endpoints not configured. \'token\' and \'login\' endpoints should be set in config.api.oauth'
+            );
+
+            tokenUri = '/oauth/token';
+        }
 
         if (this.config.prefix) {
             tokenUri = prefix + tokenUri;

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -70,7 +70,7 @@ var HttpAuthGateway = HttpGateway.extend({
      */
     handle401 : function(resolve, reject, method, path, data, headers)
     {
-        var gateway, token, refreshData, refreshHeaders, handleSuccess, handleFailure;
+        var gateway, token, refreshData, refreshHeaders, handleSuccess, handleFailure, tokenUri;
 
         gateway = this;
         token   = store.get(this.tokenStorageLocation);
@@ -105,7 +105,13 @@ var HttpAuthGateway = HttpGateway.extend({
 
         refreshHeaders = {'Content-Type' : 'application/x-www-form-urlencoded'};
 
-        this.apiRequest('POST', this.config.oauth.token, refreshData, refreshHeaders).then(handleSuccess, handleFailure);
+        tokenUri = this.config.oauth.token;
+
+        if (this.config.prefix) {
+            tokenUri = prefix + tokenUri;
+        }
+
+        this.apiRequest('POST', tokenUri, refreshData, refreshHeaders).then(handleSuccess, handleFailure);
     }
 
 });

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -105,7 +105,7 @@ var HttpAuthGateway = HttpGateway.extend({
 
         refreshHeaders = {'Content-Type' : 'application/x-www-form-urlencoded'};
 
-        this.apiRequest('POST', '/oauth/token', refreshData, refreshHeaders).then(handleSuccess, handleFailure);
+        this.apiRequest('POST', this.config.oauth.token, refreshData, refreshHeaders).then(handleSuccess, handleFailure);
     }
 
 });

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -108,11 +108,9 @@ var HttpAuthGateway = HttpGateway.extend({
         if (this.config.oauth && this.config.oauth.token) {
             tokenUri = this.config.oauth.token;
         } else {
-            console.warn(
+            throw new Error(
                 'Oauth endpoints not configured. \'token\' and \'login\' endpoints should be set in config.api.oauth'
             );
-
-            tokenUri = '/oauth/token';
         }
 
         this.apiRequest('POST', tokenUri, refreshData, refreshHeaders).then(handleSuccess, handleFailure);

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -115,10 +115,6 @@ var HttpAuthGateway = HttpGateway.extend({
             tokenUri = '/oauth/token';
         }
 
-        if (this.config.prefix) {
-            tokenUri = this.config.prefix + tokenUri;
-        }
-
         this.apiRequest('POST', tokenUri, refreshData, refreshHeaders).then(handleSuccess, handleFailure);
     }
 

--- a/http/gateway.js
+++ b/http/gateway.js
@@ -14,7 +14,7 @@ var HttpGateway = Extendable.extend({
             return this.config;
         }
 
-        throw 'You must extend getConfig or set this.config with a hostname and port';
+        throw new Error('You must extend getConfig or set this.config with a hostname and port');
     },
 
     /**

--- a/http/gateway.js
+++ b/http/gateway.js
@@ -93,6 +93,10 @@ var HttpGateway = Extendable.extend({
             }
         }
 
+        if (config.prefix) {
+            path = config.prefix + path;
+        }
+
         return {
             hostname        : config.hostname,
             port            : config.port,


### PR DESCRIPTION
### Acceptance Criteria
1.  `auth-gateway` looks at the config to build the refresh token request
1. If no oauth endpionts are configured the gateway falls back to `/oauth/token` and gives a warning
1. Api requests are prefixed with the `proxy.hostname config` variable if it exists