### PR TITLE
Match Media Store Overwrites When Rendered On Server

### DIFF
--- a/store/match-media.js
+++ b/store/match-media.js
@@ -79,7 +79,12 @@ module.exports = Fluxxor.createStore({
 
     fromObject : function(state)
     {
-        this.mqls = state.mqls;
+        if (
+            typeof window === 'undefined' ||
+            typeof window.matchMedia !== 'function'
+        ) {
+            this.mqls = state.mqls;
+        }
     },
 
     toObject : function()


### PR DESCRIPTION
## Description

The match-media store is overwriting window values with values from the server. The fromObject method should be updated to only set the mqls if window.matchMedia is unavailable.
