### PR TITLE
Auth gateway 401 handler doesn't refresh the token multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@ synapse-common
 ==============
 
 Base project code for the [Front End Template](https://github.com/synapsestudios/frontend-template).
+
+## Running Tests
+
+1. `npm install`
+2. `gulp test`
+3. Open test server in a brower. (Look for a line like `Server started http://localhost:9001`)

--- a/__tests__/http/auth-gateway-test.js
+++ b/__tests__/http/auth-gateway-test.js
@@ -1,0 +1,72 @@
+/* global describe, it, beforeEach */
+'use strict';
+
+var proxyquire   = require('proxyquireify')(require);
+var sinon        = require('sinon');
+var expect       = require('chai').expect;
+var EventEmitter = require('events').EventEmitter;
+
+var TOKEN_URI = 'TOKEN_URI';
+var HOSTNAME  = 'HOSTNAME';
+
+describe('auth-gateway', function () {
+    var HttpGateway, AuthGateway, authGateway, https;
+
+    beforeEach(function () {
+        https = sinon.spy();
+
+        HttpGateway = proxyquire(
+            '../../http/gateway',
+            {
+                q     : sinon.spy(),
+                http  : sinon.spy(),
+                https : https
+            }
+        );
+
+        AuthGateway = proxyquire(
+            '../../http/auth-gateway',
+            {
+                store       : {get : sinon.stub().returns({})},
+                './gateway' : HttpGateway
+            }
+        );
+
+        authGateway = new AuthGateway();
+        authGateway.config = {
+            client_id : '123',
+            hostname  : HOSTNAME,
+            secure    : true,
+            oauth     : {
+                logout : 'logout',
+                token  : TOKEN_URI
+            }
+        };
+    });
+
+    describe('handle401', function () {
+        var response, sendRequest, tokenRequests, apiCalls;
+
+        beforeEach(function () {
+            apiCalls = [];
+            response = new EventEmitter();
+            response.statusCode = 401;
+
+            https.request = function (options, callback) {
+                apiCalls.push(options.path);
+                callback(response);
+                response.emit('end');
+            };
+
+            sendRequest = function () {
+                authGateway.apiRequest('GET', '/foo', {}, {});
+            };
+        });
+
+        it('makes a request to get a new access token if the response is 401', function () {
+            sendRequest();
+
+            expect(1).to.equal(1);
+        });
+    });
+});

--- a/__tests__/http/auth-gateway-test.js
+++ b/__tests__/http/auth-gateway-test.js
@@ -85,23 +85,8 @@ describe('auth-gateway', function () {
         it('does not make multiple token refresh requests if multiple parallel responses return 401', function () {
             sendRequest();
             sendRequest();
-            sendRequest();
-            sendRequest();
 
             expect(tokenExchangeRequests()).to.equal(1);
-        });
-
-        it('refreshes token every time a request returns 401 if not currently refreshing the token', function () {
-            sendRequest();
-
-            failWith401 = false;
-            sendRequest();
-            sendRequest();
-
-            failWith401 = true;
-            sendRequest();
-
-            expect(tokenExchangeRequests()).to.equal(3);
         });
     });
 });

--- a/__tests__/http/auth-gateway-test.js
+++ b/__tests__/http/auth-gateway-test.js
@@ -6,8 +6,9 @@ var sinon        = require('sinon');
 var expect       = require('chai').expect;
 var EventEmitter = require('events').EventEmitter;
 
-var TOKEN_URI = 'TOKEN_URI';
-var HOSTNAME  = 'HOSTNAME';
+var TOKEN_URI    = 'TOKEN_URI';
+var HOSTNAME     = 'HOSTNAME';
+var ACCESS_TOKEN = 'ACCESS_TOKEN';
 
 describe('auth-gateway', function () {
     var HttpGateway, AuthGateway, authGateway, https;
@@ -27,7 +28,7 @@ describe('auth-gateway', function () {
         AuthGateway = proxyquire(
             '../../http/auth-gateway',
             {
-                store       : {get : sinon.stub().returns({})},
+                store       : {get : sinon.stub().returns({access_token : ACCESS_TOKEN})},
                 './gateway' : HttpGateway
             }
         );

--- a/__tests__/http/auth-gateway-test.js
+++ b/__tests__/http/auth-gateway-test.js
@@ -45,7 +45,7 @@ describe('auth-gateway', function () {
     });
 
     describe('handle401', function () {
-        var response, sendRequest, tokenRequests, apiCalls;
+        var response, sendRequest, tokenRequests, apiCalls, tokenExchangeRequests;
 
         beforeEach(function () {
             apiCalls = [];
@@ -61,12 +61,27 @@ describe('auth-gateway', function () {
             sendRequest = function () {
                 authGateway.apiRequest('GET', '/foo', {}, {});
             };
+
+            tokenExchangeRequests = function () {
+                return apiCalls.filter(function (path) {
+                    return path === TOKEN_URI;
+                }).length;
+            };
         });
 
         it('makes a request to get a new access token if the response is 401', function () {
             sendRequest();
 
-            expect(1).to.equal(1);
+            expect(tokenExchangeRequests()).to.equal(1);
+        });
+
+        it('does not make multiple token refresh requests if multiple parallel responses return 401', function () {
+            sendRequest();
+            sendRequest();
+            sendRequest();
+            sendRequest();
+
+            expect(tokenExchangeRequests()).to.equal(1);
         });
     });
 });

--- a/__tests__/http/gateway-test.js
+++ b/__tests__/http/gateway-test.js
@@ -13,9 +13,9 @@ describe('http-gateway', function() {
         HttpGateway = proxyquire(
             '../../http/gateway',
             {
-                'q'       : sinon.spy(),
-                'http'    : sinon.spy(),
-                'https'   : sinon.spy()
+                q     : sinon.spy(),
+                http  : sinon.spy(),
+                https : sinon.spy()
             }
         );
 

--- a/__tests__/index.html
+++ b/__tests__/index.html
@@ -1,11 +1,11 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>React DOM Tests</title>
+    <title>JavaScript Tests</title>
     <link rel="stylesheet" type="text/css" href="mocha.css" />
     <link rel="icon" id="favicon" type="image/png" href="favicon.png?<!-- @echo TIMESTAMP -->" />
     <script src="mocha.js"></script>
-    <script>mocha.setup('bdd')</script>
+    <script>mocha.setup('bdd');</script>
 </head>
 <body>
     <div id="mocha"></div>
@@ -73,7 +73,7 @@
 
                 image.src = 'favicon.png';
             }
-        };
+        }
 
         (function () {
             mocha.run(function(failed) {

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -41,13 +41,27 @@ var HttpAuthGateway = HttpGateway.extend({
         return options;
     },
 
+    getCurrentAccessToken : function()
+    {
+        return store.get(this.tokenStorageLocation).access_token;
+    },
+
     /**
      * {@inheritDoc}
      */
     handleError : function(response, responseData, resolve, reject, method, path, data, headers)
     {
         if (response.statusCode === 401) {
-            this.handle401(resolve, reject, method, path, data, headers);
+            var tokenJustUpdated, accessToken;
+
+            accessToken      = headers.Authorization.substring(this.authorizationHeaderPrefix.length);
+            tokenJustUpdated = (accessToken !== this.getCurrentAccessToken());
+
+            if (tokenJustUpdated) {
+                this.apiRequest(method, path, data, headers).then(resolve, reject);
+            } else {
+                this.handle401(resolve, reject, method, path, data, headers);
+            }
 
             return;
         }

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -49,12 +49,12 @@ var HttpAuthGateway = HttpGateway.extend({
     /**
      * {@inheritDoc}
      */
-    handleError : function(response, responseData, resolve, reject, method, path, data, headers)
+    handleError : function(response, responseData, resolve, reject, method, path, data, headers, options)
     {
         if (response.statusCode === 401) {
             var tokenJustUpdated, accessToken;
 
-            accessToken      = headers.Authorization.substring(this.authorizationHeaderPrefix.length);
+            accessToken      = options.headers.Authorization.substring(this.authorizationHeaderPrefix.length);
             tokenJustUpdated = (accessToken !== this.getCurrentAccessToken());
 
             if (tokenJustUpdated) {

--- a/http/gateway.js
+++ b/http/gateway.js
@@ -63,7 +63,7 @@ var HttpGateway = Extendable.extend({
                     }
 
                     if (response.statusCode >= 400) {
-                        gateway.handleError(response, responseData, resolve, reject, method, path, data, headers);
+                        gateway.handleError(response, responseData, resolve, reject, method, path, data, headers, options);
                     } else {
                         resolve(responseData);
                     }
@@ -250,7 +250,7 @@ var HttpGateway = Extendable.extend({
      * @param  {Object}   data         The failed request body data (if any)
      * @param  {Object}   headers      The extra headers set on the failed request
      */
-    handleError : function(response, responseData, resolve, reject, method, path, data, headers)
+    handleError : function(response, responseData, resolve, reject, method, path, data, headers, options)
     {
         reject(new HttpError(responseData, response));
     }


### PR DESCRIPTION
## Auth gateway 401 handler doesn't refresh the token multiple times
When the oAuth token expires the `HttpAuthGateway.handle401()` method will attempt to refresh the token EVEN IF the token is already in the middle of being refreshed.

### ACs
1. Only one token refresh will be attempted at a given time

### Tasks
1. When `handle401()` is called it will set a loading flag in local storage and trigger a refresh call
1. If the loading flag is already set then `handle401()` will simply register a listener to the `TOKEN_REFRESH_SUCCESS` event. The listener will reattempt the api call that triggered the `handle401()` call in the first place.
1. When the token refresh attempt is completed successfully the `TOKEN_REFRESH_SUCCESS ` event will be fired
1. If the refresh fails then fire `TOKEN_REFRESH_FAILURE`