### PR TITLE
Improve API for NPM Package

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var Dispatcher      = require('./lib/dispatcher');
 var MatchMediaStore = require('./store/match-media');
 var DataProvider    = require('./test-helper/data-provider');
 var FluxComponent   = require('./test-helper/flux-component');
-var MockFlux        = require('./test-helper/mock-flux');
 
 module.exports = {
     Gateway         : Gateway,
@@ -14,6 +13,5 @@ module.exports = {
     Dispatcher      : Dispatcher,
     MatchMediaStore : MatchMediaStore,
     DataProvider    : DataProvider,
-    FluxComponent   : FluxComponent,
-    MockFlux        : MockFlux
+    FluxComponent   : FluxComponent
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,19 @@
+var Gateway         = require('./http/gateway');
+var AuthGateway     = require('./http/auth-gateway');
+var ArrayObject     = require('./lib/array-object');
+var Dispatcher      = require('./lib/dispatcher');
+var MatchMediaStore = require('./store/match-media');
+var DataProvider    = require('./test-helper/data-provider');
+var FluxComponent   = require('./test-helper/flux-component');
+var MockFlux        = require('./test-helper/mock-flux');
+
+module.exports = {
+    Gateway         : Gateway,
+    AuthGateway     : AuthGateway,
+    ArrayObject     : ArrayObject,
+    Dispatcher      : Dispatcher,
+    MatchMediaStore : MatchMediaStore,
+    DataProvider    : DataProvider,
+    FluxComponent   : FluxComponent,
+    MockFlux        : MockFlux
+};


### PR DESCRIPTION
## Improve API for NPM Package

It'd be nice if instead of `require('synapse-common/http/auth-gateway')` and `require('synapse-common/store/match-media')` we could just do:

```JS
require('synapse-common').MatchMediaStore
require('synapse-common').AuthGateway
```

### Acceptance Criteria
1. Index file exists with references to 

### Tasks
- Create index file, reference it in package.json

### Additional Notes
- I'm not certain if we could still require things by path, so this might be BC breaking.