### PR TITLE
Refresh token handling broken

### DIFF
--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -123,7 +123,7 @@ var HttpAuthGateway = HttpGateway.extend({
 
             dispatcher.once('TOKEN_REFRESH_SUCCESS', function () {
                 // Delete Authorization header so that it gets replaced with the updated token
-                delete(headers.Authorization);
+                delete headers.Authorization;
 
                 gateway.apiRequest(method, path, data, headers).then(resolve, reject);
             });
@@ -148,7 +148,7 @@ var HttpAuthGateway = HttpGateway.extend({
      */
     handleTokenExchangeSuccess : function(token, method, path, data, headers, resolve, reject, response)
     {
-        token = _.extend(token, response.data);
+        token = _.extend(token, response);
 
         store.set(this.tokenStorageLocation, token);
 


### PR DESCRIPTION
## Description

It was refactored to work on lively, and now it's broken for all other apps. The refresh request is dispatched, but the re-sent requests are all sent with the original token.