### PR TITLE
Auth gateway only retries first request after handling 401

### DIFF
--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -120,14 +120,14 @@ var HttpAuthGateway = HttpGateway.extend({
                 handleSuccess,
                 _(this.handleTokenExchangeFailure).bind(this)
             );
-
-            dispatcher.once('TOKEN_REFRESH_SUCCESS', function () {
-                // Delete Authorization header so that it gets replaced with the updated token
-                delete headers.Authorization;
-
-                gateway.apiRequest(method, path, data, headers).then(resolve, reject);
-            });
         }
+
+        dispatcher.once('TOKEN_REFRESH_SUCCESS', function () {
+            // Delete Authorization header so that it gets replaced with the updated token
+            delete headers.Authorization;
+
+            gateway.apiRequest(method, path, data, headers).then(resolve, reject);
+        });
     },
 
     /**


### PR DESCRIPTION
## Description
The auth gateway is only retrying the first api request that it receives when handling a 401 unauthorized response and trying to refresh the token. This causes the front end to hang if it tried submitting multiple api requests and received 401s for all of them.

## Details
https://github.com/synapsestudios/synapse-common/blob/master/http/auth-gateway.js#L124