### PR TITLE
Error when AuthGateway tries to handle 401 response without Authorization request header

### DIFF
--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -62,7 +62,7 @@ var HttpAuthGateway = HttpGateway.extend({
         options,
         responseHeaders
     ) {
-        if (response.statusCode === 401) {
+        if (response.statusCode === 401 && requestHeaders.Authorization) {
             return this.handle401(resolve, reject, method, path, data, requestHeaders);
         }
 


### PR DESCRIPTION
An error occurs when the AuthGateway gets back a 401 response if the request didn't have an Authorization header, since it tries refreshing a token that doesn't exist.