### PR TITLE
Tokens aren't refreshing correctly

### DIFF
--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -113,17 +113,26 @@ var HttpAuthGateway = HttpGateway.extend({
 
             data = data || {};
 
-            handleSuccess = _(this.handleTokenExchangeSuccess.bind(this))
-                .partial(token, method, path, data, headers, resolve, reject);
+            handleSuccess = _.partial(
+                this.handleTokenExchangeSuccess.bind(this),
+                token,
+                method,
+                path,
+                data,
+                headers,
+                resolve,
+                reject
+            );
 
             this.makeTokenExchangeRequest(
                 token.refresh_token,
                 handleSuccess,
-                _(this.handleTokenExchangeFailure).bind(this)
+                _.bind(this.handleTokenExchangeFailure, this)
             );
         }
 
         dispatcher.once('TOKEN_REFRESH_SUCCESS', function () {
+            debugger;
             // Delete Authorization header so that it gets replaced with the updated token
             delete headers.Authorization;
 

--- a/http/auth-gateway.js
+++ b/http/auth-gateway.js
@@ -132,7 +132,6 @@ var HttpAuthGateway = HttpGateway.extend({
         }
 
         dispatcher.once('TOKEN_REFRESH_SUCCESS', function () {
-            debugger;
             // Delete Authorization header so that it gets replaced with the updated token
             delete headers.Authorization;
 


### PR DESCRIPTION
Lodash does chaining different than underscore, so changing to lodash caused the auth-gateway to not be able to refresh tokens correctly. 

```
handleSuccess = _(this.handleTokenExchangeSuccess.bind(this))
                .partial(token, method, path, data, headers, resolve, reject);
```

When using underscore, handleSuccess is a wrapper.
When using lodash, handleSuccess is a LodashWrapper.

We're not using the chaining here anyway, so let's just use the normal notation.