### PR TITLE
replace underscore references with equivalent lodash references

### DIFF
--- a/store/match-media.js
+++ b/store/match-media.js
@@ -1,7 +1,7 @@
 /* globals window */
 'use strict';
 
-var _       = require('underscore');
+var _       = require('lodash');
 var Fluxxor = require('fluxxor');
 
 /**
@@ -49,7 +49,7 @@ module.exports = Fluxxor.createStore({
             defaultMatch = null;
         }
 
-        this.mqls = _.mapObject(queries, function (query, alias) {
+        this.mqls = _.mapValues(queries, function (query, alias) {
             var mql = {
                 matches : alias === defaultMatch
             };
@@ -72,7 +72,7 @@ module.exports = Fluxxor.createStore({
      */
     getMatches : function()
     {
-        return _.mapObject(this.mqls, function (query) {
+        return _.mapValues(this.mqls, function (query) {
             return query.matches;
         });
     },

--- a/test-helper/mock-flux.js
+++ b/test-helper/mock-flux.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _     = require('underscore');
+var _     = require('lodash');
 var sinon = require('sinon');
 
 var Flux = function(stores, actions) {


### PR DESCRIPTION
Underscore was removed as a dependency, but there's still a couple references to it that need to be updated to lodash.

The lodash equivalent to underscores `mapObject` function is `mapValues`.
